### PR TITLE
添加新创建MVVM-Rhine的Activity模板时自动注册到AndroidManifest功能

### DIFF
--- a/MVVMActTemplate/recipe.xml.ftl
+++ b/MVVMActTemplate/recipe.xml.ftl
@@ -2,6 +2,9 @@
 <#import "root://activities/common/kotlin_macros.ftl" as kt>
 <recipe>
     <@kt.addAllKotlinDependencies />
+    
+    <merge from="root/AndroidManifest.xml.ftl"
+           to="${escapeXmlAttribute(manifestOut)}/AndroidManifest.xml" />
 
     <instantiate from="root/res/layout/activity.xml"
                  to="${escapeXmlAttribute(resOut)}/layout/${activity_layout}.xml" />

--- a/MVVMActTemplate/root/AndroidManifest.xml.ftl
+++ b/MVVMActTemplate/root/AndroidManifest.xml.ftl
@@ -1,0 +1,5 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+        <activity android:name="${packageName}.${className}"/>
+    </application>
+</manifest>


### PR DESCRIPTION
发现每次创建MVVM-Rhine中的Activity模板时不会注册到AndroidManifest文件中，因此这个PR将其补上